### PR TITLE
std namespace prefix is added to isnan calls

### DIFF
--- a/pr2_calibration_controllers/src/wrist_calibration_controller.cpp
+++ b/pr2_calibration_controllers/src/wrist_calibration_controller.cpp
@@ -446,8 +446,8 @@ void WristCalibrationController::update()
 
       // Determines the actuator zero position from the desired joint zero positions
       transmission_->propagatePositionBackwards(fake_js, fake_as);
-      if (isnan(fake_as[LEFT_MOTOR]->state_.position_) ||
-          isnan(fake_as[RIGHT_MOTOR]->state_.position_))
+      if (std::isnan(fake_as[LEFT_MOTOR]->state_.position_) ||
+          std::isnan(fake_as[RIGHT_MOTOR]->state_.position_))
       {
         ROS_ERROR("Restarting calibration because a computed offset was NaN. If this happens "
                   "repeatedly it may indicate a hardware failure.  (namespace: %s)",

--- a/pr2_mechanism_controllers/src/pr2_odometry.cpp
+++ b/pr2_mechanism_controllers/src/pr2_odometry.cpp
@@ -164,13 +164,13 @@ namespace controller {
     return true;
 
     for(int i=0; i < base_kin_.num_wheels_; i++)
-      if(isnan(base_kin_.wheel_[i].joint_->velocity_) || 
-          isnan(base_kin_.wheel_[i].joint_->velocity_))
+      if(std::isnan(base_kin_.wheel_[i].joint_->velocity_) || 
+          std::isnan(base_kin_.wheel_[i].joint_->velocity_))
         return false;
 
     for(int i=0; i < base_kin_.num_casters_; i++)
-      if(isnan(base_kin_.caster_[i].joint_->velocity_) || 
-          isnan(base_kin_.caster_[i].joint_->velocity_))
+      if(std::isnan(base_kin_.caster_[i].joint_->velocity_) || 
+          std::isnan(base_kin_.caster_[i].joint_->velocity_))
         return false;
 
     return true;


### PR DESCRIPTION
Without the prefix clang refuses to compile:

```
error: use of undeclared identifier 'isnan'; did you mean 'std::isnan'?
      if (isnan(fake_as[LEFT_MOTOR]->state_.position_) ||
          ^~~~~
          std::isnan
```
