### PR TITLE
Make sure to include the correct boost libraries.

### DIFF
--- a/ethercat_trigger_controllers/include/ethercat_trigger_controllers/multi_trigger_controller.h
+++ b/ethercat_trigger_controllers/include/ethercat_trigger_controllers/multi_trigger_controller.h
@@ -35,6 +35,8 @@
 #ifndef TRIGGER_CONTROLLER_H
 #define TRIGGER_CONTROLLER_H
 
+#include <vector>
+
 #include <ros/node_handle.h>
 #include <pr2_controller_interface/controller.h>
 #include <pr2_mechanism_model/robot.h>
@@ -42,7 +44,8 @@
 #include <ethercat_trigger_controllers/MultiWaveform.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <std_msgs/Header.h>
-#include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
 
 /** @class MultiMultiTriggerController
   * @brief Allows complex periodic triggering waveforms through a digital output

--- a/ethercat_trigger_controllers/src/multi_trigger_controller.cpp
+++ b/ethercat_trigger_controllers/src/multi_trigger_controller.cpp
@@ -34,6 +34,8 @@
  *********************************************************************/
 
 #include <boost/format.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include "ethercat_trigger_controllers/multi_trigger_controller.h"
 #include "ros/console.h"

--- a/joint_trajectory_action/src/joint_trajectory_action.cpp
+++ b/joint_trajectory_action/src/joint_trajectory_action.cpp
@@ -29,6 +29,8 @@
 
 // Author: Stuart Glaser
 
+#include <boost/bind.hpp>
+
 #include <ros/ros.h>
 #include <actionlib/server/action_server.h>
 

--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/caster_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/caster_calibration_controller.h
@@ -34,6 +34,9 @@
 #ifndef CASTER_CALIBRATION_CONTROLLER_H
 #define CASTER_CALIBRATION_CONTROLLER_H
 
+#include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include "ros/node_handle.h"
 #include "pr2_mechanism_controllers/caster_controller.h"
 #include "realtime_tools/realtime_publisher.h"

--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/fake_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/fake_calibration_controller.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-
+#include <boost/scoped_ptr.hpp>
 
 #include "pr2_mechanism_model/robot.h"
 #include "robot_mechanism_controllers/joint_velocity_controller.h"

--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/gripper_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/gripper_calibration_controller.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-
+#include <boost/scoped_ptr.hpp>
 
 #include "pr2_mechanism_model/robot.h"
 #include "robot_mechanism_controllers/joint_velocity_controller.h"

--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/joint_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/joint_calibration_controller.h
@@ -35,6 +35,9 @@
 #ifndef PR2_JOINT_CALIBRATION_CONTROLLER
 #define PR2_JOINT_CALIBRATION_CONTROLLER
 
+#include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include "ros/node_handle.h"
 #include "pr2_mechanism_model/robot.h"
 #include "robot_mechanism_controllers/joint_velocity_controller.h"

--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/wrist_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/wrist_calibration_controller.h
@@ -34,6 +34,9 @@
 #ifndef WRIST_CALIBRATION_CONTROLLER_H
 #define WRIST_CALIBRATION_CONTROLLER_H
 
+#include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include "robot_mechanism_controllers/joint_velocity_controller.h"
 #include "realtime_tools/realtime_publisher.h"
 #include "pr2_mechanism_model/wrist_transmission.h"

--- a/pr2_gripper_action/src/pr2_gripper_action.cpp
+++ b/pr2_gripper_action/src/pr2_gripper_action.cpp
@@ -31,6 +31,8 @@
 
 #include "ros/ros.h"
 
+#include <boost/bind.hpp>
+
 #include <actionlib/server/action_server.h>
 #include <pr2_controllers_msgs/JointControllerState.h>
 #include <pr2_controllers_msgs/Pr2GripperCommand.h>

--- a/pr2_head_action/src/pr2_point_frame.cpp
+++ b/pr2_head_action/src/pr2_point_frame.cpp
@@ -35,8 +35,8 @@
 #include <ros/ros.h>
 
 #include <vector>
+#include <boost/bind.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 
 #include <actionlib/server/action_server.h>
 #include <geometry_msgs/PoseStamped.h>

--- a/pr2_mechanism_controllers/include/pr2_mechanism_controllers/laser_scanner_traj_controller.h
+++ b/pr2_mechanism_controllers/include/pr2_mechanism_controllers/laser_scanner_traj_controller.h
@@ -56,8 +56,7 @@
 #include <pr2_msgs/SetPeriodicCmd.h>
 #include <pr2_msgs/SetLaserTrajCmd.h>
 
-#include "boost/thread/mutex.hpp"
-#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
 #include "pr2_mechanism_controllers/trajectory.h"
 
 namespace controller

--- a/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_base_controller.h
+++ b/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_base_controller.h
@@ -44,7 +44,6 @@
 #include <angles/angles.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 #include <filters/transfer_function.h>
 
 namespace controller

--- a/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_base_controller2.h
+++ b/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_base_controller2.h
@@ -44,7 +44,6 @@
 #include <angles/angles.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 #include <filters/transfer_function.h>
 
 namespace controller

--- a/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_gripper_controller.h
+++ b/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_gripper_controller.h
@@ -64,7 +64,6 @@
 #include <control_toolbox/pid.h>
 #include <control_toolbox/pid_gains_setter.h>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 #include <realtime_tools/realtime_box.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <std_msgs/Float64.h>

--- a/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_odometry.h
+++ b/pr2_mechanism_controllers/include/pr2_mechanism_controllers/pr2_odometry.h
@@ -43,7 +43,6 @@
 #include <angles/angles.h>
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 
 #include <std_msgs/Float64.h>
 #include <pr2_mechanism_controllers/OdometryMatrix.h>

--- a/pr2_mechanism_controllers/src/base_kinematics.cpp
+++ b/pr2_mechanism_controllers/src/base_kinematics.cpp
@@ -35,6 +35,8 @@
  * Author: Sachin Chitta and Matthew Piccoli
  */
 
+#include <boost/shared_ptr.hpp>
+
 #include <pr2_mechanism_controllers/base_kinematics.h>
 #include <kdl/tree.hpp>
 

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/cartesian_pose_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/cartesian_pose_controller.h
@@ -71,7 +71,6 @@
 
 #include <vector>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 
 #include <ros/node_handle.h>
 

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/cartesian_wrench_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/cartesian_wrench_controller.h
@@ -65,7 +65,6 @@
 #include <tf/transform_datatypes.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 
 
 namespace controller {

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_position_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_position_controller.h
@@ -64,7 +64,6 @@
 #include <control_toolbox/pid.h>
 #include "control_toolbox/pid_gains_setter.h"
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 #include <realtime_tools/realtime_publisher.h>
 #include <std_msgs/Float64.h>
 #include <pr2_controllers_msgs/JointControllerState.h>

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_spline_trajectory_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_spline_trajectory_controller.h
@@ -40,8 +40,7 @@
 #include <vector>
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/recursive_mutex.hpp>
-#include <boost/thread/condition.hpp>
+#include <boost/shared_ptr.hpp>
 #include <ros/node_handle.h>
 #include <control_toolbox/pid.h>
 #include <pr2_controller_interface/controller.h>

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_trajectory_action_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_trajectory_action_controller.h
@@ -40,8 +40,7 @@
 #include <vector>
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/recursive_mutex.hpp>
-#include <boost/thread/condition.hpp>
+#include <boost/shared_ptr.hpp>
 #include <ros/node_handle.h>
 
 #include <actionlib/server/action_server.h>

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_velocity_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_velocity_controller.h
@@ -61,7 +61,6 @@
 
 #include <ros/node_handle.h>
 #include <boost/scoped_ptr.hpp>
-#include <boost/thread/condition.hpp>
 
 #include "pr2_controller_interface/controller.h"
 #include "control_toolbox/pid.h"

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/jt_cartesian_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/jt_cartesian_controller.h
@@ -37,6 +37,8 @@
 #ifndef PR2_CONTROLLERS_JT_CARTESIAN_CONTROLLER_H
 #define PR2_CONTROLLERS_JT_CARTESIAN_CONTROLLER_H
 
+#include <boost/scoped_ptr.hpp>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 

--- a/robot_mechanism_controllers/src/cartesian_pose_controller.cpp
+++ b/robot_mechanism_controllers/src/cartesian_pose_controller.cpp
@@ -32,6 +32,7 @@
  */
 
 
+#include <boost/bind.hpp>
 
 #include "robot_mechanism_controllers/cartesian_pose_controller.h"
 #include <algorithm>

--- a/robot_mechanism_controllers/src/joint_spline_trajectory_controller.cpp
+++ b/robot_mechanism_controllers/src/joint_spline_trajectory_controller.cpp
@@ -31,6 +31,8 @@
  * Author: Stuart Glaser
  */
 
+#include <boost/shared_ptr.hpp>
+
 #include "robot_mechanism_controllers/joint_spline_trajectory_controller.h"
 #include <sstream>
 #include "angles/angles.h"

--- a/robot_mechanism_controllers/src/joint_trajectory_action_controller.cpp
+++ b/robot_mechanism_controllers/src/joint_trajectory_action_controller.cpp
@@ -31,6 +31,9 @@
  * Author: Stuart Glaser
  */
 
+#include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
+
 #include "robot_mechanism_controllers/joint_trajectory_action_controller.h"
 #include <sstream>
 #include "angles/angles.h"

--- a/single_joint_position_action/src/single_joint_position_action.cpp
+++ b/single_joint_position_action/src/single_joint_position_action.cpp
@@ -34,6 +34,8 @@
 
 #include <cmath>
 
+#include <boost/bind.hpp>
+
 #include <ros/ros.h>
 #include <actionlib/server/action_server.h>
 


### PR DESCRIPTION
This follows the principle of "include what you use", and
also should fix the problems on the build farm in http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ethercat_trigger_controllers__ubuntu_bionic_amd64__binary.  I'll be honest; I don't understand why it just started failing now, but in my testing this does seem to fix the problem.

@k-okada A review, merge, and release to Melodic would be appreciated so we can do a Melodic sync. Thanks!