### PR TITLE
Remove actionlib typedefs defined upstream

### DIFF
--- a/robot_mechanism_controllers/CMakeLists.txt
+++ b/robot_mechanism_controllers/CMakeLists.txt
@@ -23,7 +23,11 @@ catkin_package(
    LIBRARIES robot_mechanism_controllers
 )
 
-add_definitions(-O3)
+string(REPLACE "." ";" VERSION_LIST ${actionlib_VERSION})
+list(GET VERSION_LIST 0 actionlib_VERSION_MAJOR)
+list(GET VERSION_LIST 1 actionlib_VERSION_MINOR)
+list(GET VERSION_LIST 2 actionlib_VERSION_PATCH)
+add_definitions(-O3 -Dactionlib_VERSION=${actionlib_VERSION} -Dactionlib_VERSION_MAJOR=${actionlib_VERSION_MAJOR} -Dactionlib_VERSION_MINOR=${actionlib_VERSION_MINOR} -Dactionlib_VERSION_PATCH=${actionlib_VERSION_PATCH})
 
 add_library(robot_mechanism_controllers
     src/cartesian_pose_controller.cpp

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_trajectory_action_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_trajectory_action_controller.h
@@ -69,6 +69,10 @@ private:
 
   //typedef actionlib::ActionServer<Action>::GoalHandle GoalHandle;
   typedef actionlib::ServerGoalHandle<Action> GoalHandle;
+#if ((actionlib_VERSION_MAJOR == 1) && (actionlib_VERSION_MINOR < 12)) || (actionlib_VERSION_MAJOR < 1)
+  typedef boost::shared_ptr<Result> ResultPtr;
+  typedef boost::shared_ptr<Feedback> FeedbackPtr;
+#endif
 
   uint8_t state_;
 

--- a/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_trajectory_action_controller.h
+++ b/robot_mechanism_controllers/include/robot_mechanism_controllers/joint_trajectory_action_controller.h
@@ -69,8 +69,6 @@ private:
 
   //typedef actionlib::ActionServer<Action>::GoalHandle GoalHandle;
   typedef actionlib::ServerGoalHandle<Action> GoalHandle;
-  typedef boost::shared_ptr<Result> ResultPtr;
-  typedef boost::shared_ptr<Feedback> FeedbackPtr;
 
   uint8_t state_;
 


### PR DESCRIPTION
This is needed to build successfully since https://github.com/ros/actionlib/pull/145 was merged. Long term, it looks like RTServerGoalHandle could be replaced with a dependency on [`ros-controls/realtime_tools`](https://github.com/ros-controls/realtime_tools/blob/melodic-devel/include/realtime_tools/realtime_server_goal_handle.h)