### PR TITLE
Improve joint calibration controller

### DIFF
--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/joint_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/joint_calibration_controller.h
@@ -43,6 +43,7 @@
 #include "robot_mechanism_controllers/joint_velocity_controller.h"
 #include "realtime_tools/realtime_publisher.h"
 #include "std_msgs/Empty.h"
+#include "std_msgs/Float32.h"
 #include "pr2_controllers_msgs/QueryCalibrationState.h"
 
 
@@ -65,12 +66,13 @@ public:
 protected:
   pr2_mechanism_model::RobotState* robot_;
   ros::NodeHandle node_;
-  ros::Time last_publish_time_;
   ros::ServiceServer is_calibrated_srv_;
   boost::scoped_ptr<realtime_tools::RealtimePublisher<std_msgs::Empty> > pub_calibrated_;
+  boost::scoped_ptr<realtime_tools::RealtimePublisher<std_msgs::Float32> > pub_zero_offset_;
 
   enum { INITIALIZED, BEGINNING, MOVING_TO_LOW, MOVING_TO_HIGH, CALIBRATED };
   int state_;
+  bool announced_calibration_success_;
   int countdown_;
 
   double search_velocity_;

--- a/pr2_calibration_controllers/include/pr2_calibration_controllers/joint_calibration_controller.h
+++ b/pr2_calibration_controllers/include/pr2_calibration_controllers/joint_calibration_controller.h
@@ -74,6 +74,7 @@ protected:
   int state_;
   bool announced_calibration_success_;
   int countdown_;
+  int tics_moving_past_calibration_reading_;
 
   double search_velocity_;
   double original_position_;

--- a/pr2_calibration_controllers/src/joint_calibration_controller.cpp
+++ b/pr2_calibration_controllers/src/joint_calibration_controller.cpp
@@ -90,6 +90,9 @@ bool JointCalibrationController::init(pr2_mechanism_model::RobotState *robot, ro
     return false;
   }
 
+  tics_moving_past_calibration_reading_ = 200;
+  node_.getParam("tics_moving_past_calibration_reading", tics_moving_past_calibration_reading_);
+
   bool force_calibration = false;
   node_.getParam("force_calibration", force_calibration);
 
@@ -227,7 +230,7 @@ void JointCalibrationController::update()
       }
     }
     else
-      countdown_ = 200;
+      countdown_ = tics_moving_past_calibration_reading_;
     break;
   case MOVING_TO_HIGH: {
     vc_.setCommand(search_velocity_);


### PR DESCRIPTION
This makes the calibration controllers more flexible without changing behavior in an inappropriate way.
The only change in existing functionality is that the `calibrated` topic will only be published once as a latch message instead of continuously announcing over and over again to the same clients that it finished calibrating.

This works together with https://github.com/TAMS-Group/tams_pr2_refine_startup_calibration to provide a more accurate initialization to detect the hardware zero crossings. In practice we can reduce the noise (one sample per startup) of detection from up to 0.2rad(!) to around 0.01-0.02 depending on the joint.

I am utterly confused why nobody looked into this before and although our transmission belts might be especially loose the procedure can definitely also improve precision of other group's robots.

@k-okada I use this on our PR2. Are you ok with me merging this here?